### PR TITLE
Using row-fluid instead of row in html.

### DIFF
--- a/webserver/home/templates/home/entries.html
+++ b/webserver/home/templates/home/entries.html
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row-fluid">
   {% for entry in entries %}
     <div class="span4">
       <h2>{{ entry.title }}</h2>

--- a/webserver/profiles/templates/profiles/view_profile.html
+++ b/webserver/profiles/templates/profiles/view_profile.html
@@ -7,11 +7,12 @@
     <div class="span9">
       <div class="well">
         <h2>{% firstof userprofile.user.get_full_name userprofile.user.username %}</h2>
-        {% if userprofile.has_badges%}<div class="row-fluid">
-            <div class="span12">
+          {% if userprofile.has_badges%}<div class="row-fluid">
+              <div class="span12">
                 <!-- Badges go here -->
+              </div>
             </div>
-        {% endif %}
+          {% endif %}
         <h4 class="muted"><i>{{ userprofile.user.username }}</i></h4>
         <p>
           {{ userprofile.rendered_about_me|safe }}

--- a/webserver/profiles/templates/profiles/view_profile.html
+++ b/webserver/profiles/templates/profiles/view_profile.html
@@ -3,10 +3,15 @@
 
 {% block content %}
 
-  <div class="row">
-    <div class="span6">
+  <div class="row-fluid">
+    <div class="span9">
       <div class="well">
         <h2>{% firstof userprofile.user.get_full_name userprofile.user.username %}</h2>
+        {% if userprofile.has_badges%}<div class="row-fluid">
+            <div class="span12">
+                <!-- Badges go here -->
+            </div>
+        {% endif %}
         <h4 class="muted"><i>{{ userprofile.user.username }}</i></h4>
         <p>
           {{ userprofile.rendered_about_me|safe }}
@@ -14,22 +19,9 @@
       </div>
     </div>
     <div class="span3">
-      <div class="row">
-        <div class="span3">
-          <ul class="thumbnails">
-            <li class="span3">
-              <a href="#" class="thumbnail">
-                <img src="{% gravatar_url userprofile.user.email %}" />
-              </a>
-            </li>
-          </ul>
-        </div>
-      </div>
-      <div class="row">
-        <div class="span3">
-          <!-- Badges go here -->
-        </div>
-      </div>
+      <a href="#" class="thumbnail">
+        <img src="{% gravatar_url userprofile.user.email %}" />
+      </a>
     </div>
   </div>
 

--- a/webserver/templates/base.html
+++ b/webserver/templates/base.html
@@ -78,7 +78,7 @@
 
       <div class="container">
         {% include "_messages.html" %}
-        <div class="row">
+        <div class="row-fluid">
           <div id="content" class="span9">
             {% block page-header %}
             {% endblock %}


### PR DESCRIPTION
I've changed several templates (all the places I could identify) that used row instead of row-fluid. "row" doesn't nest as nicely as row-fluid and it was causing your index view to bulge on one side which made it non-centered. I also removed several superflous looking divs around the avatar in the profiles page.
