### PR TITLE
Fix that makes the media uploads work correctly.

### DIFF
--- a/webserver/urls.py
+++ b/webserver/urls.py
@@ -29,17 +29,18 @@ urlpatterns = patterns(
     url(r'^admin_tools/', include('admin_tools.urls')),
 )
 
+if settings.DEBUG:
+    urlpatterns += patterns(
+        '',
+        url(r'^media/(?P<path>.*)$', 'django.views.static.serve',
+            {'document_root': settings.MEDIA_ROOT,'show_indexes':True}),
+        url(r'^static/(?P<path>.*)$', 'django.views.static.serve',
+            {'document_root': settings.STATIC_ROOT}),
+    )
+
 # Flat pages
 urlpatterns += patterns(
     'django.contrib.flatpages.views',
     url(r'^(?P<url>.*)$', 'flatpage'),
 )
 
-if settings.DEBUG:
-    urlpatterns += patterns(
-        '',
-        url(r'^media/(?P<path>.*)$', 'django.views.static.serve',
-            {'document_root': settings.MEDIA_ROOT}),
-        url(r'^static/(?P<path>.*)$', 'django.views.static.serve',
-            {'document_root': settings.STATIC_ROOT}),
-    )


### PR DESCRIPTION
I found an issue while developing that I couldn't get the team avatars to show up. For some reason the flat page url rule was absorbing the media rules and preventing them from working. A change of order seems to have fixed that.
