### PR TITLE
Update homepage, add new docs page

### DIFF
--- a/webserver/home/templates/home/docs.html
+++ b/webserver/home/templates/home/docs.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% load flatpages %}
+
+{% block title %}
+  Documentation
+{% endblock %}
+
+{% block page-header %}
+  <div class="page-header">
+    <h1>MegaMinerAI Documentation</h1>
+  </div>
+{% endblock %}
+
+{% block content %}
+  <ul style="list-style-type: none;">
+    {% get_flatpages '/docs/' for user as flatpages %}
+    {% for page in flatpages %}
+      <li>
+        <a href="{{ page.get_absolute_url }}">{{ page.title }}</a>
+      </li>
+    {% empty %}
+      <li class="disabled">
+        <a href="#">No documentation sets available</a>
+      </li>
+    {% endfor %}
+  </ul>
+{% endblock %}

--- a/webserver/home/templates/home/home_unauthenticated.html
+++ b/webserver/home/templates/home/home_unauthenticated.html
@@ -4,7 +4,7 @@
 </div>
 
 <!-- carousel -->
-<div id="carousel" class="carousel slide">
+<div id="carousel" class="carousel slide hidden-sm hidden-xs">
   <!-- carousel Indicators -->
   <ol class="carousel-indicators">
     <li data-target="#carousel" data-slide-to="0" class="active"></li>
@@ -25,10 +25,10 @@
     </div>
     <div class="item">
       <img src="http://i.imgur.com/6r8NdhI.png">
-    </div> 
+    </div>
     <div class="item">
       <img src="http://i.imgur.com/NfMij96.png">
-    </div>      
+    </div>
   </div>
   <!-- carousel Controls -->
   <a class="left carousel-control" href="#carousel" data-slide="prev">
@@ -36,5 +36,5 @@
   </a>
   <a class="right carousel-control" href="#carousel" data-slide="next">
     <span class="glyphicon glyphicon-chevron-right"></span>
-  </a>  
+  </a>
 </div>

--- a/webserver/home/urls.py
+++ b/webserver/home/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import patterns, url
 
-from views import HomePageView
+from views import HomePageView, DocsPageView
 
 
 urlpatterns = patterns(
@@ -8,4 +8,7 @@ urlpatterns = patterns(
     url(r'^$',
         HomePageView.as_view(),
         name='home'),
+    url(r'^docs/$',
+        DocsPageView.as_view(),
+        name="docs"),
 )

--- a/webserver/home/views.py
+++ b/webserver/home/views.py
@@ -5,7 +5,7 @@ from competition.models import Competition
 
 class HomePageView(TemplateView):
     template_name = "home/home.html"
-    
+
     def get_context_data(self, **kwargs):
         context = super(HomePageView, self).get_context_data(**kwargs)
 
@@ -15,3 +15,5 @@ class HomePageView(TemplateView):
             context["closed_competitions"] = my_competitions.filter(is_running=False, is_open=False)
         return context
 
+class DocsPageView(TemplateView):
+    template_name = "home/docs.html"

--- a/webserver/static/css/mobile.css
+++ b/webserver/static/css/mobile.css
@@ -1,0 +1,3 @@
+#comp_img {
+	width:62%;
+}

--- a/webserver/templates/base.html
+++ b/webserver/templates/base.html
@@ -38,9 +38,9 @@
             <!-- Helps the navbar collapse when the page shrinks -->
             <button class="navbar-toggle collapsed" data-toggle="collapse"
                     data-target=".navbar-collapse">
-              <span class="glyphicon glyphicon-bar"></span>
-              <span class="glyphicon glyphicon-bar"></span>
-              <span class="glyphicon glyphicon-bar"></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
             </button>
           <!--mve this /div down with other...maybe-->
           </div>

--- a/webserver/templates/navbar/_competition.html
+++ b/webserver/templates/navbar/_competition.html
@@ -1,31 +1,8 @@
 {% load url from future %}
 {% load competition_tags %}
 
-<li id="competition-tab" class="dropdown">
-
-  <a href="#" class="toggle-dropdown" data-toggle="dropdown">
-    Competition
+<li id="competition-tab">
+  <a href="{% url 'competition_list' %}">
+    Competitions
   </a>
-
-  <ul class="dropdown-menu" role="menu">
-    <li>
-      <a href="{% url 'competition_list' %}">
-        Competitions
-      </a>
-    </li>
-
-    {% if user.is_authenticated %}
-      <li class="divider"></li>
-      <li id="your-competitions" class="disabled"
-          title="These are the competitions that you've registered for!">
-        <a href="#" data-toggle="tooltip">
-          Your Competitions
-        </a>
-      </li>
-
-      {# List competitions that the user is registered for #}
-      {% competitions_registered %}
-    {% endif %}
-
-  </ul>
 </li>

--- a/webserver/templates/navbar/_documentation.html
+++ b/webserver/templates/navbar/_documentation.html
@@ -1,21 +1,8 @@
 {% load url from future %}
 {% load flatpages %}
 
-<li id="documentation-tab" class="dropdown">
-  <a href="#" class="toggle-dropdown" data-toggle="dropdown">
+<li id="documentation-tab">
+  <a href="{% url 'docs' %}">
     Documentation
   </a>
-
-  <ul class="dropdown-menu" role="menu">
-    {% get_flatpages '/docs/' for user as flatpages %}
-    {% for page in flatpages %}
-      <li>
-        <a href="{{ page.get_absolute_url }}">{{ page.title }}</a>
-      </li>
-    {% empty %}
-      <li class="disabled">
-        <a href="#">No documentation sets available</a>
-      </li>
-    {% endfor %}
-  </ul>
 </li>


### PR DESCRIPTION
- A couple of pages were completely broken on mobile resolutions.  They look much better now.
  - Carousel removed from homepage on mobile resolutions  
- The documentation links are no longer in the navbar dropdown, they are now displayed on /docs/
- fixes #82 
